### PR TITLE
Support explicit `undefined` default value on `TSOCDataAccessor`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ interface TSOCDataAccessor<T> {
    * Data accessor without a default value. If no data exists,
    * `undefined` is returned.
    */
-  (): Defined<T> | undefined;
+  (noDefaultValue?: undefined): Defined<T> | undefined;
 
   /**
    * Data accessor with default value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-transform-optchain",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A TypeScript custom transformer for Optional Chaining",
   "main": "./dist/index.js",
   "types": "./index.d.ts",

--- a/src/__tests__/transform-test.ts
+++ b/src/__tests__/transform-test.ts
@@ -61,6 +61,7 @@ describe('ts-optchain', () => {
     };
 
     expect(oc(x).a()).toEqual(x.a);
+    expect(oc(x).a(undefined)).toEqual(x.a);
     expect(oc(x).b.d()).toEqual(x.b && x.b.d);
     expect(oc(x).c[0].u.v()).toEqual(x.c && x.c[0] && x.c[0].u && (x as any).c[0].u.v);
     expect(oc(x).c[100].u.v()).toEqual(x.c && x.c[100] && x.c[100].u && (x as any).c[100].u.v);


### PR DESCRIPTION
For completeness, adds support for passing explicit `undefined` default value to TSOCDataAccessor. This also addresses an issue found in some versions of TypeScript whereby return type is not inferred correctly.